### PR TITLE
Remove deprecated 'edition2024' cargo feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "uuinfo"
 version = "0.4.2"

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -2,7 +2,7 @@ use colored::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::formats::snowflake::{
-    SnowflakeAnnotation, annotate_discord, annotate_flakeid, annotate_frostflake, annotate_instagram, annotate_linkedin, annotate_mastodon, annotate_sony, annotate_spaceflake, annotate_twitter,
+    annotate_discord, annotate_flakeid, annotate_frostflake, annotate_instagram, annotate_linkedin, annotate_mastodon, annotate_sony, annotate_spaceflake, annotate_twitter, SnowflakeAnnotation,
 };
 use crate::id_format::ALL_PARSERS;
 use crate::schema::{Args, TimestampComparable};

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use std::cmp;
-use std::io::{Write, stdout};
+use std::io::{stdout, Write};
 
 use clap::ValueEnum;
 use colored::*;

--- a/src/formats/pushid.rs
+++ b/src/formats/pushid.rs
@@ -1,5 +1,5 @@
 use base64::engine::GeneralPurpose;
-use base64::{Engine as _, alphabet, engine};
+use base64::{alphabet, engine, Engine as _};
 use std::fmt::Write;
 
 use crate::schema::{Args, IDInfo};

--- a/src/formats/scru.rs
+++ b/src/formats/scru.rs
@@ -1,5 +1,5 @@
-use scru64::Scru64Id;
 use scru128::Scru128Id;
+use scru64::Scru64Id;
 use std::fmt::Write;
 use uuid::Uuid;
 

--- a/src/formats/threads.rs
+++ b/src/formats/threads.rs
@@ -1,4 +1,4 @@
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use std::fmt::Write;
 
 use crate::schema::{Args, IDInfo};

--- a/src/formats/unix.rs
+++ b/src/formats/unix.rs
@@ -204,13 +204,11 @@ mod tests {
 
     #[test]
     fn test_parse_unix_recent_none() {
-        assert!(
-            parse_unix_recent(&Args {
-                id: "1000000000".to_string(),
-                ..Default::default()
-            })
-            .is_none()
-        );
+        assert!(parse_unix_recent(&Args {
+            id: "1000000000".to_string(),
+            ..Default::default()
+        })
+        .is_none());
     }
 
     #[test]

--- a/src/formats/uuid.rs
+++ b/src/formats/uuid.rs
@@ -1,4 +1,4 @@
-use base64::{Engine as _, engine::general_purpose::URL_SAFE, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{engine::general_purpose::URL_SAFE, engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use short_uuid::{CustomTranslator, ShortUuidCustom};
 use std::fmt::Write;
 use uuid::{Uuid, Variant};

--- a/src/formats/youtube.rs
+++ b/src/formats/youtube.rs
@@ -1,4 +1,4 @@
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use std::fmt::Write;
 
 use crate::schema::{Args, IDInfo};

--- a/src/id_format.rs
+++ b/src/id_format.rs
@@ -16,7 +16,7 @@ use crate::formats::nuid::parse_nuid;
 use crate::formats::objectid::parse_objectid;
 use crate::formats::puid::{parse_puid, parse_puid_any, parse_shortpuid};
 use crate::formats::pushid::parse_pushid;
-use crate::formats::scru::{parse_scru64, parse_scru128};
+use crate::formats::scru::{parse_scru128, parse_scru64};
 use crate::formats::snowflake::parse_snowflake;
 use crate::formats::sqid::parse_sqid;
 use crate::formats::stripe::parse_stripe;
@@ -28,7 +28,7 @@ use crate::formats::typeid::parse_typeid;
 use crate::formats::ulid::parse_ulid;
 use crate::formats::unix::{parse_unix, parse_unix_ms, parse_unix_ns, parse_unix_recent, parse_unix_s, parse_unix_us};
 use crate::formats::upid::parse_upid;
-use crate::formats::uuid::{parse_base64_uuid, parse_short_uuid, parse_uuid, parse_uuid_integer, parse_uuid25};
+use crate::formats::uuid::{parse_base64_uuid, parse_short_uuid, parse_uuid, parse_uuid25, parse_uuid_integer};
 use crate::formats::xid::parse_xid;
 use crate::formats::youtube::parse_youtube;
 


### PR DESCRIPTION
Rust 1.85 stabilized edition 2024, so using `cargo-features = ["edition2024"]` is no longer necessary. This also caused some default formatting rules to change, hence the code changes (import order is re-arranged in some modules).